### PR TITLE
Disable management of resources by rbenv

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@ class waylon::install (
   $ruby_version,
   $unicorn_version,
   $waylon_version,
+  $manage_deps = true,
 ) {
 
   # build-essential and libssl-dev are req'd for the rbenv ruby-build plugin.
@@ -20,6 +21,7 @@ class waylon::install (
   class { '::rbenv':
     install_dir => $rbenv_install_path,
     latest      => true,
+    manage_deps => $manage_deps,
   }
 
   rbenv::plugin { 'sstephenson/ruby-build':


### PR DESCRIPTION
The rbenv puppet module installs a bunch of packages that we already
manage, and the waylon module depends on rbenv.

This change sets the manage_deps parameter on it to false. Note that the
manage_deps parameter isn't merged in yet and is in
https://github.com/justindowning/puppet-rbenv/pull/57, so this won't
work with the currently released puppet-rbenv.
